### PR TITLE
pre-commit autoupdate 2026-03-27

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,18 +10,18 @@ repos:
     -   id: double-quote-string-fixer
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 8.0.1
     hooks:
     -   id: isort
         args: ["--profile", "black"]
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.3.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 26.3.1
     hooks:
     -   id: black
         args: ["--skip-string-normalization"]
@@ -33,7 +33,7 @@ repos:
         additional_dependencies: ["types-PyYAML"]
 
 -   repo: https://github.com/espressif/check-copyright/
-    rev: v1.0.1
+    rev: v1.1.2
     hooks:
     -   id: check-copyright
         args: ['--config', '.copyright-config.yaml']

--- a/sample.py
+++ b/sample.py
@@ -18,24 +18,21 @@ def main():
     formatter.set_options('--style=mozilla --mode=c')
 
     # Original source to format
-    source = textwrap.dedent(
-        '''
+    source = textwrap.dedent('''
         int main(int argc, char** argv) {
           if (argc == 0) {
             return 1;
           }
           return 0;
         }
-        '''
-    ).strip()
+        ''').strip()
 
     # Format!
     result: str = formatter.format(source)
     print(result)
 
     # This should be the result
-    expected = textwrap.dedent(
-        '''
+    expected = textwrap.dedent('''
         int main(int argc, char** argv)
         {
             if (argc == 0) {
@@ -43,8 +40,7 @@ def main():
             }
             return 0;
         }
-        '''
-    ).strip()
+        ''').strip()
     assert result == expected
 
 

--- a/test/test_files_iter.py
+++ b/test/test_files_iter.py
@@ -78,8 +78,7 @@ def test_iter_rules(tmp_path: pathlib.Path):
     all_files = sorted(str(p.relative_to(base)) for p in tmp_path.glob('**/*.c'))
     assert len(all_files) == 4
 
-    rules_str = textwrap.dedent(
-        """
+    rules_str = textwrap.dedent("""
         DEFAULT:
             options: "--opt1 --opt2=foo"
             check: true
@@ -98,8 +97,7 @@ def test_iter_rules(tmp_path: pathlib.Path):
             include:
                 - "/**/sub2/"
             options: "--opt7 --opt8=ffs"
-    """
-    )
+    """)
     rules_file = tmp_path / 'rules'
     rules_file.write_text(rules_str)
 


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.0.1 -> v6.0.0
[https://github.com/pycqa/isort] updating 5.11.5 -> 8.0.1
[https://github.com/pycqa/flake8] updating 5.0.4 -> 7.3.0
[https://github.com/psf/black] updating 22.6.0 -> 26.3.1
[https://github.com/pre-commit/mirrors-mypy] updating v0.971 -> v1.19.1  # I reverted the mypy upgrade.
[https://github.com/espressif/check-copyright/] updating v1.0.1 -> v1.1.2
```
% `pre-commit run --all-files`

psf/black changes for the "stable style 2026".  https://black.readthedocs.io/en/stable/the_black_code_style/index.html